### PR TITLE
feat: add support for `makezero`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -23,7 +23,7 @@ linters:
     - nolintlint # Ill-formed or insufficient nolint directives
     #- nlreturn # Checks for a new line before return and branch statements to increase code clarity
     - misspell # Misspelled English words in comments
-    #- makezero # Finds slice declarations with non-zero initial length
+    - makezero # Finds slice declarations with non-zero initial length
     - lll # Long lines
     #- importas # Enforces consistent import aliases
     - gosec # Security problems
@@ -54,3 +54,4 @@ issues:
       linters:
         - gosec # Disabled linting of weak number generators
         - lll # Disabled linting of long test case lines
+        - makezero # Disabled linting of intentional slice appends

--- a/pkgs/crypto/bip39/bip39.go
+++ b/pkgs/crypto/bip39/bip39.go
@@ -201,7 +201,7 @@ func addChecksum(data []byte) []byte {
 
 func padByteSlice(slice []byte, length int) []byte {
 	newSlice := make([]byte, length-len(slice))
-	return append(newSlice, slice...)
+	return append(newSlice, slice...) //nolint:makezero
 }
 
 func validateEntropyBitSize(bitSize int) error {


### PR DESCRIPTION
# Description

This PR adds support for the `makezero` linter, and resolves pending linting errors.
